### PR TITLE
Adding Show/Hide error messages

### DIFF
--- a/src/examples.ts
+++ b/src/examples.ts
@@ -25,6 +25,7 @@ export const examples = [
       responseType: 'text',
       withCredentials: false,
       skipSameURL: true,
+      showErrors: true,
 
       showTime: false,
       showTimePrefix: null,

--- a/src/module.ts
+++ b/src/module.ts
@@ -464,8 +464,10 @@ class AjaxCtrl extends MetricsPanelCtrl {
     }
 
     let txt = `<h1>${msg}</h1>`;
-    if (err) {
+    if (err && this.panel.showErrors) {
       txt += '<pre>' + JSON.stringify(err) + '</pre>';
+    } else {
+      txt += '<pre>Something went wrong while executing your request.</pre>';
     }
 
     this.ngtemplate.html(txt);

--- a/src/partials/editor.request.html
+++ b/src/partials/editor.request.html
@@ -69,6 +69,13 @@
 			label-class="width-9" 
 			checked="ctrl.panel.skipSameURL" 
 			on-change="ctrl.onConfigChanged()"></gf-form-switch>
+		<gf-form-switch 
+		class="gf-form" 
+		tooltip="Show/Hide error messages."
+		label="Show Errors" 
+		label-class="width-9" 
+		checked="ctrl.panel.showErrors" 
+		on-change="ctrl.onConfigChanged()"></gf-form-switch>
 	</div>
 
 


### PR DESCRIPTION
Sometimes is very important don't show response errors. They can contain sensitive data as Application Tokens in its headers and you don't want that showed at a TV screen for example.